### PR TITLE
Authentication service test tooling

### DIFF
--- a/authentication-service/blokat-authentication/config/environment/environment.stag.ts
+++ b/authentication-service/blokat-authentication/config/environment/environment.stag.ts
@@ -119,6 +119,7 @@ export const configuration: Configuration = {
     password: process.env.POSTGRES_PASSWORD,
     url: 'user-db',
     port: '5432',
+    database: 'studieplekken_users',
   },
 
   jwtKey: process.env.JWT_KEY,

--- a/authentication-service/blokat-authentication/config/environment/environment.test.ts
+++ b/authentication-service/blokat-authentication/config/environment/environment.test.ts
@@ -41,7 +41,7 @@ export const configuration: Configuration = {
     password: 'postgres',
     url: 'localhost',
     port: '5432',
-    database: 'studieplekken_users'
+    database: 'studieplekken_users_test',
   },
 
   jwtKey: "local-key",

--- a/authentication-service/blokat-authentication/package.json
+++ b/authentication-service/blokat-authentication/package.json
@@ -85,7 +85,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
@@ -94,6 +94,8 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "roots": ["<rootDir>"],
+    "modulePaths": ["<rootDir>"]
   }
 }

--- a/authentication-service/blokat-authentication/package.json
+++ b/authentication-service/blokat-authentication/package.json
@@ -16,11 +16,11 @@
     "init-db": "npx dotenv -e  .env.staging -- prisma migrate deploy",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "cp": "mkdirp dist && ncp ./config ./dist/config",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test": "NODE_ENV=test jest",
+    "test:watch": "NODE_ENV=test jest --watch",
+    "test:cov": "NODE_ENV=test jest --coverage",
+    "test:debug": "NODE_ENV=test node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "NODE_ENV=test jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/authentication-service/blokat-authentication/src/app.controller.spec.ts
+++ b/authentication-service/blokat-authentication/src/app.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AuthModule } from './auth/auth.module';
+import { ConfigModule } from './configModule/config.module';
 import { DbModule } from './db/db.module';
 
 describe('AppController', () => {
@@ -9,7 +10,7 @@ describe('AppController', () => {
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      imports: [AuthModule, DbModule],
+      imports: [AuthModule, DbModule, ConfigModule],
     }).compile();
 
     appController = app.get<AppController>(AppController);

--- a/authentication-service/blokat-authentication/src/auth/auth.service.spec.ts
+++ b/authentication-service/blokat-authentication/src/auth/auth.service.spec.ts
@@ -1,9 +1,9 @@
 import { JwtModule } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getConfig } from 'src/configModule/config.service';
 import { ConfigModule } from '../configModule/config.module';
 import { DbModule } from '../db/db.module';
 import { AuthService } from './auth.service';
-import { jwtConstants } from './constants';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -14,7 +14,7 @@ describe('AuthService', () => {
         DbModule,
         ConfigModule,
         JwtModule.register({
-          secret: jwtConstants.secret,
+          secret: getConfig().jwtKey,
           signOptions: { expiresIn: '60s' },
         }),
       ],

--- a/authentication-service/blokat-authentication/src/auth/saml/saml.strategy.spec.ts
+++ b/authentication-service/blokat-authentication/src/auth/saml/saml.strategy.spec.ts
@@ -18,16 +18,6 @@ describe('SamlService', () => {
     expect(service).toBeDefined();
   });
 
-  it('Should generate the metadata', () => {
-    const cert = fs
-      .readFileSync(
-        path.join(__dirname, '../../../config/auth/saml', './cert.pem'),
-      )
-      .toString();
-    console.log(service.generateServiceProviderMetadata(cert, cert));
-    expect(service.generateServiceProviderMetadata(cert, cert)).toBeDefined();
-  });
-
   it('Should read metadata from a file', () => {
     expect(readMetadata('./meta-idp.xml')).toBeDefined();
   });

--- a/authentication-service/blokat-authentication/src/configModule/config.service.ts
+++ b/authentication-service/blokat-authentication/src/configModule/config.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { configuration as development_config } from '../../config/environment/environment.dev';
 import { configuration as staging_config } from '../../config/environment/environment.stag';
+import { configuration as test_config } from '../../config/environment/environment.test';
 
 import { assert } from 'console';
 import { Configuration } from './config';
@@ -18,7 +19,7 @@ export class ConfigService {
 
 const configMap: Map<string, Configuration> = new Map();
 configMap.set(DEVELOPMENT_STRING, development_config);
-configMap.set(TEST_STRING, development_config);
+configMap.set(TEST_STRING, test_config);
 configMap.set(STAG_STRING, staging_config);
 
 export function getConfig() {

--- a/authentication-service/blokat-authentication/src/configModule/config.ts
+++ b/authentication-service/blokat-authentication/src/configModule/config.ts
@@ -80,6 +80,7 @@ export interface Configuration {
     username: string;
     password: string;
     port: string;
+    database: string;
   };
 
   jwtKey: string;

--- a/authentication-service/blokat-authentication/src/db/db-token/db-token.service.spec.ts
+++ b/authentication-service/blokat-authentication/src/db/db-token/db-token.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from 'src/configModule/config.service';
+import { DbService } from '../db.service';
 import { DbTokenService } from './db-token.service';
 
 describe('DbTokenService', () => {
@@ -6,7 +8,7 @@ describe('DbTokenService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DbTokenService],
+      providers: [DbTokenService, DbService, ConfigService],
     }).compile();
 
     service = module.get<DbTokenService>(DbTokenService);

--- a/authentication-service/blokat-authentication/src/db/db-user/db-user.service.spec.ts
+++ b/authentication-service/blokat-authentication/src/db/db-user/db-user.service.spec.ts
@@ -11,6 +11,9 @@ describe("DbUserService", () => {
       providers: [DbUserService, DbService, ConfigService],
     }).compile();
 
+    const dbService = module.get<DbService>(DbService);
+    dbService.wipe();
+
     service = module.get<DbUserService>(DbUserService);
   });
 
@@ -18,8 +21,16 @@ describe("DbUserService", () => {
     expect(service).toBeDefined();
   });
 
-  it("Should fetch my user", async () => {
+  it("Should create and fetch my user", async () => {
+    const createUser = await service.create({email: "maxiem.geldhof@ugent.be", first_name: "Maxiem", last_name: "Geldhof", user_id: "0", hashed_password: "", salt: ""})
+
     const me = await service.userByEmail("maxiem.geldhof@ugent.be");
-    expect(me.first_name).toEqual("Maxiem");
+    expect(me.first_name).toEqual(createUser.first_name);
+  });
+
+
+  it("Should not find nonexistent user", async () => {
+    const me = await service.userByEmail("maxiem.geldhof@ugent.be");
+    expect(me).toEqual(null);
   });
 });

--- a/authentication-service/blokat-authentication/src/db/db.service.ts
+++ b/authentication-service/blokat-authentication/src/db/db.service.ts
@@ -9,7 +9,7 @@ export class DbService extends PrismaClient implements OnModuleInit {
     super({
       datasources: {
         db: {
-          url: `postgresql://${dbConfig.username}:${dbConfig.password}@${dbConfig.url}:${dbConfig.port}/studieplekken_users?schema=public`,
+          url: `postgresql://${dbConfig.username}:${dbConfig.password}@${dbConfig.url}:${dbConfig.port}/${dbConfig.database}?schema=public`,
         },
       },
     });

--- a/authentication-service/blokat-authentication/src/db/db.service.ts
+++ b/authentication-service/blokat-authentication/src/db/db.service.ts
@@ -1,5 +1,5 @@
 import { INestApplication, Injectable, OnModuleInit } from "@nestjs/common";
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { ConfigService } from "../configModule/config.service";
 
 @Injectable()
@@ -23,5 +23,14 @@ export class DbService extends PrismaClient implements OnModuleInit {
     this.$on("beforeExit", async () => {
       await app.close();
     });
+  }
+
+  async wipe() {
+    const modelNames = Prisma.dmmf.datamodel.models.map((model) => model.name);
+
+    return Promise.all(
+      // @ts-ignore
+      modelNames.map((modelName) => this[modelName.toLowerCase()].deleteMany()) 
+    );
   }
 }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - pgdatas:/var/lib/postgresql/data
       - ./scripts/pg-init:/docker-entrypoint-initdb.d
     environment:
-        POSTGRES_MULTIPLE_DATABASES: blokatugent, blokatugent_test, studieplekken_users
+        POSTGRES_MULTIPLE_DATABASES: blokatugent, blokatugent_test, studieplekken_users, studieplekken_users_test
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: "postgres"
         TZ: Europe/Brussels


### PR DESCRIPTION
The authentication service tests are in serious disrepair. To be able to write new tests and repair old ones, some cleanup needed to be done:
1. bumping the test versions
2. fixing rootdir issues
3. getting failing tests to pass
4. add database wipe utility which can run in the `beforeEach` clause
