### PR TITLE
chore: Bump frontend Node version to v14.21 for now

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 ### STAGE 1: Build ###
 
-FROM node:12.20-alpine AS build
+FROM node:14.21-alpine AS build
 WORKDIR /app
 RUN npm install -g @angular/cli
 COPY package.json package-lock.json ./


### PR DESCRIPTION
Temporary fix to get the frontend building again. #43 is still needed but this requires updates of the dependencies as well before we can bump node to the latest LTS version.