### PR TITLE
chore: Update the dockerfile for authservice

### DIFF
--- a/authentication-service/blokat-authentication/Dockerfile
+++ b/authentication-service/blokat-authentication/Dockerfile
@@ -1,4 +1,4 @@
-from node:16-stretch
+FROM node:16-buster
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
'stretch' is outdated & archived, so migrating to 'buster'.