### PR TITLE
fix: Fix flaky auth tests: run all tests in a transaction

### DIFF
--- a/authentication-service/blokat-authentication/src/db/db-user/db-user.service.spec.ts
+++ b/authentication-service/blokat-authentication/src/db/db-user/db-user.service.spec.ts
@@ -2,18 +2,18 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "../../configModule/config.service";
 import { DbService } from "../db.service";
 import { DbUserService } from "./db-user.service";
+import { transactionalIt } from "test/transactional-it";
 
 describe("DbUserService", () => {
   let service: DbUserService;
+  let dbService: DbService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [DbUserService, DbService, ConfigService],
     }).compile();
 
-    const dbService = module.get<DbService>(DbService);
-    dbService.wipe();
-
+    dbService = module.get<DbService>(DbService);
     service = module.get<DbUserService>(DbUserService);
   });
 
@@ -21,15 +21,14 @@ describe("DbUserService", () => {
     expect(service).toBeDefined();
   });
 
-  it("Should create and fetch my user", async () => {
+  transactionalIt(dbService, "Should create and fetch my user", async () => {
     const createUser = await service.create({email: "maxiem.geldhof@ugent.be", first_name: "Maxiem", last_name: "Geldhof", user_id: "0", hashed_password: "", salt: ""})
 
     const me = await service.userByEmail("maxiem.geldhof@ugent.be");
     expect(me.first_name).toEqual(createUser.first_name);
   });
 
-
-  it("Should not find nonexistent user", async () => {
+  transactionalIt(dbService, "Should not find nonexistent user", async () => {
     const me = await service.userByEmail("maxiem.geldhof@ugent.be");
     expect(me).toEqual(null);
   });

--- a/authentication-service/blokat-authentication/src/db/db.service.ts
+++ b/authentication-service/blokat-authentication/src/db/db.service.ts
@@ -25,12 +25,4 @@ export class DbService extends PrismaClient implements OnModuleInit {
     });
   }
 
-  async wipe() {
-    const modelNames = Prisma.dmmf.datamodel.models.map((model) => model.name);
-
-    return Promise.all(
-      // @ts-ignore
-      modelNames.map((modelName) => this[modelName.toLowerCase()].deleteMany()) 
-    );
-  }
 }

--- a/authentication-service/blokat-authentication/test/transactional-it.ts
+++ b/authentication-service/blokat-authentication/test/transactional-it.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client";
+
+export const transactionalIt = (
+  prisma: PrismaClient,
+  test_name: string,
+  test: () => Promise<unknown>,
+) =>
+  async function () {
+    await prisma.$transaction(async (prisma) => {
+      await prisma.$executeRaw`BEGIN`;
+      const itWrap = it(test_name, test);
+      await prisma.$executeRaw`ROLLBACK`;
+      return itWrap;
+    });
+  };


### PR DESCRIPTION
Instead of wiping the tables and therefore causing concurrency issues (which I can't fix for some reason), run the tests in a transaction so they can no longer collide.

I ran the tests a bunch of times over [here](https://github.com/AurisAudentis/Studieplekken/actions/runs/4901144620/jobs/8752254451?pr=2).