### PR TITLE
Do not proceed if user object is empty and always show Login button if not logged in

### DIFF
--- a/frontend/src/app/services/api/penalties/penalty.service.ts
+++ b/frontend/src/app/services/api/penalties/penalty.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Penalty } from '../../../shared/model/Penalty';
 import { api } from '../endpoints';
-import { Observable } from 'rxjs';
+import {Observable, of} from 'rxjs';
 import { PenaltyEvent } from '../../../shared/model/PenaltyEvent';
 import { map } from 'rxjs/operators';
 
@@ -19,10 +19,13 @@ export class PenaltyService {
    ****************************************/
 
   getPenaltiesOfUserById(id: string): Observable<PenaltyList> {
-    return this.http.get<any>(api.penaltiesByUserId.replace('{id}', id))
-    .pipe(
-      map(a => ({points: a.currentPoints, penalties: a.penalties.map(Penalty.fromJSON)}))
-      );
+      if (id === '') {
+          return of({points: 0, penalties: []});
+      }
+      return this.http.get<any>(api.penaltiesByUserId.replace('{id}', id))
+          .pipe(
+              map(a => ({points: a.currentPoints, penalties: a.penalties.map(Penalty.fromJSON)}))
+          );
   }
 
   addPenalty(penalty: Penalty): Observable<void> {

--- a/frontend/src/app/stad-gent-components/header/header.component.html
+++ b/frontend/src/app/stad-gent-components/header/header.component.html
@@ -6,9 +6,9 @@
         </a>
 
         <!-- The user profile / login button -->
-        <div *ngIf="getUser() | async as user">
+        <div *ngIf="getUser() | async as user; else userNotLoggedIn">
             <!-- If user is logged in -->
-            <app-accordeon class="authentication" *ngIf="user != null && user.userId != ''"
+            <app-accordeon class="authentication" *ngIf="user != null && user.userId != ''; else userNotLoggedIn"
                 [controller]="accordionSubject">
 
                 <button accordion-button aria-expanded="false" aria-controls="no-hero_auth-authentication"
@@ -22,12 +22,6 @@
                     <app-header-dropdown [isProfile]="true" [accordion]="accordionSubject"></app-header-dropdown>
                 </div>
             </app-accordeon>
-
-            <!-- If user is not logged in -->
-            <div class="authentication accordion" *ngIf="user == null || user.userId == ''">
-                <a routerLink="/login" class="login-link">
-                    {{"header.navigation.login" | translate}} </a>
-            </div>
         </div>
 
         <!-- Menu for mid sized mobile -->
@@ -109,3 +103,11 @@
 
     <hr />
 </header>
+
+<ng-template #userNotLoggedIn>
+    <!-- If user is not logged in -->
+    <div class="authentication accordion">
+        <a routerLink="/login" class="login-link">
+            {{"header.navigation.login" | translate}} </a>
+    </div>
+</ng-template>


### PR DESCRIPTION
This PR fixes #97. This hopefully reduces the amount of "unsuccessful HTTP requests' according to netdata.
It also resolves the case that sometimes the Login button was not shown in the event that `getUser() | async as user;` was false.
