### PR TITLE
chore: added email in the authority users overview

### DIFF
--- a/frontend/src/app/components/management/authorities-management/authority-users-management/authority-users-management.component.html
+++ b/frontend/src/app/components/management/authorities-management/authority-users-management/authority-users-management.component.html
@@ -22,6 +22,7 @@
                     <th scope="col">{{'management.users.searchResult.table.id' | translate}}</th>
                     <th scope="col">{{'management.users.searchResult.table.firstName' | translate}}</th>
                     <th scope="col">{{'management.users.searchResult.table.lastName' | translate}}</th>
+                    <th scope="col">{{'management.users.searchResult.table.email' | translate}}</th>
                     <th scope="col">
                         <!-- Delete -->
                     </th>
@@ -30,9 +31,12 @@
 
                 <tbody>
                 <tr *ngFor="let user of users">
-                    <td>{{user.userId}}</td>
-                    <td>{{user.firstName}}</td>
-                    <td>{{user.lastName}}</td>
+                    <td>{{ user.userId }}</td>
+                    <td>{{ user.firstName }}</td>
+                    <td>{{ user.lastName }}</td>
+                    <td>
+                        {{ user.mail.toLowerCase() }}
+                    </td>
                     <td class="hover" (click)="prepareToDeleteUserFromAuthority(user, deleteUserFromAuthorityModal)">
                       <span>
                         <i class="icon-cross" aria-hidden="true"></i>

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -570,6 +570,7 @@
                     "lastName": "Last name",
                     "penaltyPoints": "Penalty points",
                     "institution": "Institution",
+                    "email": "Email",
                     "details": "Details"
                 },
                 "neverSearched": "You haven't searched any users yet. Fill in the first and/or last name, or just the barcode to be able to search users.",

--- a/frontend/src/assets/i18n/nl.json
+++ b/frontend/src/assets/i18n/nl.json
@@ -569,6 +569,7 @@
                     "lastName": "Achternaam",
                     "penaltyPoints": "Strafpunten",
                     "institution": "Institutie",
+                    "email": "E-mail",
                     "details": "Details"
                 },
                 "neverSearched": "Je hebt nog niet gezocht naar een gebruiker. Vul de voor- en/of achternaam, of enkel de barcode in om te kunnen zoeken naar gebruikers.",


### PR DESCRIPTION
We sometimes want to be able to contact those responsible for certain locations or authorities. Their email address has been added in the overview table.